### PR TITLE
chore: enable Renovate security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
       "matchJsonata": [
         "$exists(vulnerabilityFixVersion)"
       ],
-      "labels": [
+      "addLabels": [
         "security"
       ],
       "automerge": false
@@ -40,7 +40,7 @@
   ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "labels": [
+    "addLabels": [
       "security"
     ],
     "automerge": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
       "addLabels": [
         "security"
       ],
-      "automerge": false
+      "automerge": true
     }
   ],
   "osvVulnerabilityAlerts": true,
@@ -43,7 +43,7 @@
     "addLabels": [
       "security"
     ],
-    "automerge": false,
+    "automerge": true,
     "vulnerabilityFixStrategy": "lowest"
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "helpers:pinGitHubActionDigests", "group:allNonMajor"],
-  "labels": ["Meta: Dependencies"],
-  "schedule": ["before 12pm on Sunday"],
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "group:allNonMajor",
+    ":enableVulnerabilityAlerts"
+  ],
+  "labels": [
+    "Meta: Dependencies"
+  ],
+  "schedule": [
+    "before 12pm on Sunday"
+  ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    },
+    {
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion)"
+      ],
+      "labels": [
+        "security"
+      ],
+      "automerge": false
     }
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ],
+    "automerge": false,
+    "vulnerabilityFixStrategy": "lowest"
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,21 +27,6 @@
         "major"
       ],
       "automerge": false
-    },
-    {
-      "matchJsonata": [
-        "isVulnerabilityAlert = true"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "addLabels": [
-        "security"
-      ],
-      "automerge": true
     }
   ],
   "osvVulnerabilityAlerts": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,7 +30,13 @@
     },
     {
       "matchJsonata": [
-        "$exists(vulnerabilityFixVersion)"
+        "isVulnerabilityAlert = true"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
       ],
       "addLabels": [
         "security"
@@ -43,7 +49,6 @@
     "addLabels": [
       "security"
     ],
-    "automerge": true,
     "vulnerabilityFixStrategy": "lowest"
   }
 }


### PR DESCRIPTION
## Summary

- Enables Renovate vulnerability-alert PRs sourced from GitHub Dependabot alerts.
- Enables OSV scanning as a supplemental source for supported direct dependencies.
- Labels vulnerability-fix PRs `security` and enables automerge for them after CI succeeds.
- Prefers the lowest patched version to minimize compatibility risk.
- Explicitly disables automerge for major updates.
- Preserves the repository's existing Renovate rules; deprecated `config:base` references are migrated to `config:recommended` where present.

## Validation

- JSON parsing passed.
- `renovate-config-validator` from Renovate 43.275.0 passed.
- `git diff --check` passed.
- This is configuration-only; repository code and dependency lockfiles are unchanged.

## Security sources

- **Primary advisory source:** GitHub Dependabot alerts (Renovate reads alerts; Dependabot alerts remain open).
- **Supplemental source:** OSV via `osvVulnerabilityAlerts` (supported direct dependencies only).

## Manual follow-up

- Renovate is already active in this repository. Confirm the Renovate App installation now lists **Dependabot alerts: read**; GitHub does not expose that installation permission through the current `gh` OAuth token.
- After the next Renovate run, verify that vulnerability PRs carry the `security` label and automerge after CI succeeds.
- Do not enable duplicate Dependabot security-update PR generation once Renovate security PR creation is proven. Existing Dependabot security updates were not disabled in this change to avoid a coverage gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Renovate to open security‑update PRs from GitHub Dependabot alerts and OSV, label them `security`, and auto‑merge only minor/patch/pin/digest after CI; major updates—including security majors—remain manual. Switches `extends` to `config:recommended`, preserves existing labels, prefers the lowest patched version, and removes a redundant security rule to keep automerge behavior clear.

**Rollout**
- Ensure the Renovate App installation has “Dependabot alerts: read”.
- Verify security PRs carry the `security` label and non‑major updates auto‑merge after CI.
- Do not enable duplicate Dependabot security‑update PRs until Renovate’s flow is confirmed.

<sup>Written for commit f3d3fd84eef82e1745ed4f7d8918aa09ac77ad15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TurboCheetah/iTurbo/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

